### PR TITLE
Fix broken doc comments.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,20 @@
 //! **See what's different in arbitrary data structures**.
 //!
-//! The main [`diff`] algorithm.
+//! The main [`diff`](`diff::diff`) algorithm.
 //! we implement here is less than a screen full of lines, yet it enables a vast amount of
 //! applications.
 //! It can work with all values implementing the `Value` trait.
 //!
-//! On top of it there is a [`merge`] implementation, which can be used to aggregate changes
+//! On top of it there is a [merge][`tools::Merger`] implementation, which can be used to aggregate changes
 //! into a target value. It works with `Value`s which implement the `Mutable` trait.
 //!
 //! # Usage
-//! Please have a look at the tests for [diff][diff-tests] and [merge][merge-tests] tests.
+//! Please have a look at the tests for [diff][diff-tests] and [merge][merge-tests].
 //!
 //! Also note that you will have to choose the features to build the library with in order to
 //! get trait implementations for `Value` types of common libraries,
 //! i.e. `cargo build --features=with-serde-json`.
-//! [`diff`]: fn.diff.html
-//! [`merge`]: tools/struct.Merger.html
+//!
 //! [diff-tests]: https://github.com/Byron/treediff-rs/blob/master/tests/diff.rs
 //! [merge-tests]: https://github.com/Byron/treediff-rs/blob/master/tests/merge.rs
 #![deny(missing_docs, unsafe_code)]

--- a/src/tools/merge.rs
+++ b/src/tools/merge.rs
@@ -12,6 +12,7 @@ use std::{borrow::BorrowMut, borrow::Cow, fmt::Display, marker::PhantomData};
 ///
 /// # Examples
 /// Please see the [tests][tests] for usage examples.
+///
 /// [tests]: https://github.com/Byron/treediff-rs/blob/master/tests/merge.rs#L22
 pub struct Merger<K, V, BF, F> {
     cursor: Vec<K>,

--- a/src/tools/record.rs
+++ b/src/tools/record.rs
@@ -22,6 +22,7 @@ pub enum ChangeType<'a, K, V: 'a> {
 ///
 /// # Examples
 /// Please see the [tests][tests] for how to use this type.
+///
 /// [tests]: https://github.com/Byron/treediff-rs/blob/master/tests/diff.rs#L21
 #[derive(Debug, PartialEq)]
 pub struct Recorder<'a, K, V: 'a> {


### PR DESCRIPTION
The page https://docs.rs/treediff/4.0.0/treediff/ isn't very readable because of this.

Maybe it broke with a Rust update, as rustdoc now supports linking directly by identifier, [`like_this`].
