### PR TITLE
Allow serde_yaml >= 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ version = "4.0.2"
 include = ["src/**/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 [dependencies]
-rustc-serialize = {version = "0.3.24", optional = true}
-serde_json = {version = "1.0.45", optional = true}
-serde_yaml = {version = "0.8", optional = true}
-yaml-rust = {version = "0.4", optional = true}
+rustc-serialize = { version = "0.3.24", optional = true }
+serde_json = { version = "1.0.45", optional = true }
+serde_yaml = { version = ">=0.8", optional = true }
+yaml-rust = { version = "0.4", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -26,4 +26,3 @@ with-rustc-serialize = ["rustc-serialize"]
 with-serde-json = ["serde_json"]
 with-serde-yaml = ["serde_yaml"]
 with-yaml-rust = ["yaml-rust"]
-


### PR DESCRIPTION
I think the 0.8 and 0.9 versions do not differ in terms of structures, but 0.9 had the breaking change of requiring tagging. It should be possible to simply support both versions :)